### PR TITLE
Support Embedded PubKey in PeerID Comparison

### DIFF
--- a/Sources/LibP2PNoise/ChannelHandlers/HandshakeHandler.swift
+++ b/Sources/LibP2PNoise/ChannelHandlers/HandshakeHandler.swift
@@ -186,7 +186,7 @@ internal final class InboundNoiseHandshakeHandler: ChannelInboundHandler, Remova
                                 "Validated the dialed peer! \(rpi.b58String) is in fact who they claim to be..."
                             )
                         } else if let remoteID = expectedRemotePeerID, let rid = try? PeerID(cid: remoteID) {
-                            guard rid.id == rpi.id else {
+                            guard rid == rpi else {
                                 logger.error(
                                     "Listeners Noise Handshake Identity Key does not match the Peer we dialed. Aborting Handshake and closing connection...(ExpectedRemotePeerID)"
                                 )


### PR DESCRIPTION
### What:
- We can directly compare PeerID's in our validation logic now that [swift-peer-id](https://github.com/swift-libp2p/swift-peer-id) has support for embedded pub keys
- https://github.com/swift-libp2p/swift-peer-id/pull/12

### Fixes: 
- We can now establish connections to Peers using embedded ED25519 pub keys!